### PR TITLE
Add ResNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vim
+*.swp
+*.swo

--- a/resnet/.gitignore
+++ b/resnet/.gitignore
@@ -1,0 +1,1 @@
+intel_challenge

--- a/resnet/data_loader.py
+++ b/resnet/data_loader.py
@@ -1,0 +1,54 @@
+import torch
+import torchvision.datasets as datasets
+import torchvision.transforms as transforms
+from torch.utils.data import DataLoader
+
+import distdl
+
+num_workers = 0
+
+class DummyLoader:
+
+    def __init__(self, batch_size, n_data_points):
+
+        self.batch_size = batch_size
+        self.n_data_points = n_data_points
+
+        self.n_loaded = 0
+
+        self.mod_batch_size = n_data_points % batch_size
+        self.n_batches = n_data_points // batch_size
+
+    def __iter__(self):
+        for i in range(self.n_batches):
+            yield distdl.utilities.torch.zero_volume_tensor(self.batch_size), torch.zeros(self.batch_size)
+        yield distdl.utilities.torch.zero_volume_tensor(self.mod_batch_size), torch.zeros(self.mod_batch_size)
+
+def get_data_loaders(batch_size, train_data_dir, test_data_dir,
+                     download=False, dummy=False):
+
+    data_train = datasets.ImageFolder(train_data_dir,
+                                      transforms.Compose([
+                                          transforms.Resize((500, 1000)),
+                                          transforms.ToTensor(),
+                                      ]))
+
+    data_test = datasets.ImageFolder(test_data_dir,
+                                     transforms.Compose([
+                                         transforms.Resize((500, 1000)),
+                                         transforms.ToTensor(),
+                                     ]))
+
+    if not dummy:
+        train_loader = DataLoader(data_train,
+                                  batch_size=batch_size,
+                                  shuffle=False,
+                                  num_workers=num_workers)
+        test_loader = DataLoader(data_test,
+                                 batch_size=batch_size,
+                                 num_workers=num_workers)
+    else:
+        train_loader = DummyLoader(batch_size, 14034)
+        test_loader = DummyLoader(batch_size, 3000)
+
+    return train_loader, test_loader

--- a/resnet/distributed_experiment.py
+++ b/resnet/distributed_experiment.py
@@ -1,0 +1,112 @@
+import sys
+
+import torch
+from data_loader import get_data_loaders
+from mpi4py import MPI
+from network import generate_distributed_network
+
+from distdl.utilities.torch import zero_volume_tensor
+
+torch.manual_seed(0)
+
+# Intel challenge:
+num_classes = 6
+train_data_dir = 'intel_challenge/seg_train/'
+test_data_dir = 'intel_challenge/seg_test/'
+
+resnet_distributed = generate_distributed_network(num_classes)
+
+P_base = resnet_distributed.P_base
+if not P_base.active:
+    quit()
+
+max_batch_size = 64
+
+n_epochs = 10
+
+loud = True
+
+MPI.COMM_WORLD.Barrier()
+
+parameters = [p for p in resnet_distributed.parameters()]
+if not parameters:
+    parameters = [torch.nn.Parameter(torch.zeros(1))]
+criterion = torch.nn.CrossEntropyLoss()
+optimizer = torch.optim.Adam(parameters, lr=1e-3)
+
+if P_base.rank == 0:
+    training_loader, test_loader = get_data_loaders(max_batch_size,
+                                                    train_data_dir,
+                                                    test_data_dir,
+                                                    download=False,
+                                                    dummy=False)
+else:
+    training_loader, test_loader = get_data_loaders(max_batch_size,
+                                                    train_data_dir,
+                                                    test_data_dir,
+                                                    download=False,
+                                                    dummy=True)
+
+# Adapted from https://github.com/activatedgeek/LeNet-5/blob/master/run.py
+loss_list, batch_list = [], []
+
+tt = MPI.Wtime()
+for epoch in range(n_epochs):
+    tte = MPI.Wtime()
+
+    for i, (images, labels) in enumerate(training_loader):
+
+        ttp = MPI.Wtime()
+
+        optimizer.zero_grad()
+
+        output = resnet_distributed(images)
+
+        # Compute the loss after forward prop. For now, we do this on rank 0 because
+        # CrossEntropy is nonlinear, meaning it cannot be simply sumreduced across
+        # all ranks to acheive the correct results.
+        if P_base.rank == 0:
+            loss = criterion(output, labels)
+            loss_list.append(loss.detach().cpu().item())
+            batch_list.append(i + 1)
+            if loud and i % 1 == 0:
+                print(f'Epoch {epoch}, Batch {i}, Loss: {loss_list[-1]}, time: {MPI.Wtime() - ttp}')
+                sys.stdout.flush()
+        else:
+            loss = output.clone()
+
+        loss.backward()
+        optimizer.step()
+
+    if P_base.rank == 0:
+        print(f"Epoch {epoch} time: {MPI.Wtime() - tte}")
+        sys.stdout.flush()
+
+if P_base.rank == 0:
+    print(f"Total time: {MPI.Wtime() - tt}")
+    sys.stdout.flush()
+
+resnet_distributed.eval()
+
+total = 0
+total_correct = 0
+avg_loss = 0.0
+
+with torch.no_grad():
+
+    for i, (images, labels) in enumerate(test_loader):
+
+        total += max_batch_size
+        output = resnet_distributed(images)
+        if P_base.rank == 0:
+            pred = output.detach().max(1)[1]
+            total_correct += pred.eq(labels.view_as(pred)).sum()
+
+            if loud and i % 10 == 0:
+                print(f'Test Batch {i}')
+                sys.stdout.flush()
+
+perc = float(total_correct) / float(total)
+
+P_base.print_sequential(f"Rank {P_base.rank}, Total Correct: {total_correct}, Total: {total}, %: {perc}")
+sys.stdout.flush()

--- a/resnet/layers.py
+++ b/resnet/layers.py
@@ -1,0 +1,50 @@
+import torch
+
+import distdl
+from distdl.utilities.torch import zero_volume_tensor
+
+
+class DistributedNetworkOutputFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, input, partition):
+
+        ctx.partition = partition
+        ctx.sh = input.shape
+
+        if partition.rank == 0:
+            return input.clone()
+        else:
+            return torch.tensor([0.0], requires_grad=True).float()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+
+        partition = ctx.partition
+        sh = ctx.sh
+
+        if partition.rank == 0:
+            return grad_output.clone(), None
+        else:
+            return zero_volume_tensor(sh[0]), None
+
+
+class DistributedNetworkOutput(distdl.nn.Module):
+
+    def __init__(self, partition):
+        super(DistributedNetworkOutput, self).__init__()
+        self.partition = partition
+
+    def forward(self, input):
+
+        return DistributedNetworkOutputFunction.apply(input, self.partition)
+
+
+class Flatten(torch.nn.Module):
+
+    def __init__(self):
+        super(Flatten, self).__init__()
+
+    def forward(self, input):
+        batch_size = input.size(0)
+        return input.view(batch_size, -1)

--- a/resnet/network.py
+++ b/resnet/network.py
@@ -1,0 +1,17 @@
+from mpi4py import MPI
+from torchvision.models import resnet18
+from resnet_dist import resnet18_dist
+
+import distdl
+
+
+def generate_sequential_network(num_classes):
+
+    return resnet18(num_classes=num_classes)
+
+def generate_distributed_network(num_classes):
+
+    P_world = distdl.backend.backend.Partition(MPI.COMM_WORLD)
+    P_world._comm.Barrier()
+
+    return resnet18_dist(P_world, parts=[4, 8], num_classes=num_classes)

--- a/resnet/readme.md
+++ b/resnet/readme.md
@@ -1,0 +1,11 @@
+This is a DistDL implementation of the ResNet series of networks, described here: https://arxiv.org/pdf/1512.03385.pdf
+
+The DistDL implementation is based on the TorchVision implementation:  https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
+
+Loading pre-computed models is not currently supported.
+
+The current example is designed to train on the Intel Image Classification challege.  This is largely because the data set is small and this is only an example.  Many real-world applications ahve terabytes of image data for training.  Just as a demonstration, we artificially upscale the input images.
+
+To run, download the data from here (https://www.kaggle.com/puneet6060/intel-image-classificationhttps://neurohive.io/en/popular-networks/vgg16/) and populate the `intel_challenge` directory as shown by the experiment scripts.
+
+You can supply a different partitioning of the input tensors in `network.py` by supplying a different `parts` parameter.  The number of MPI processes should be at least as much as `parts[0] * parts[1]`.

--- a/resnet/resnet_dist.py
+++ b/resnet/resnet_dist.py
@@ -1,0 +1,498 @@
+# Adapted from https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py under
+# the Torchvision license, reproduced below.  All modifications follow the standard DistDL
+# license.
+
+# BSD 3-Clause License
+
+# Copyright (c) Soumith Chintala 2016, All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import torch
+import numpy as np
+from torch import Tensor
+import torch.nn as nn
+from typing import Type, Any, Callable, Union, List, Optional
+
+from layers import DistributedNetworkOutput
+import distdl
+
+
+__all__ = ['DistributedResNet', 'resnet18_dist', 'resnet34_dist', 'resnet50_dist', 'resnet101_dist',
+           'resnet152_dist', 'resnext50_32x4d_dist', 'resnext101_32x8d_dist',
+           'wide_resnet50_2_dist', 'wide_resnet101_2_dist']
+
+
+model_urls = {
+    'resnet18': 'https://download.pytorch.org/models/resnet18-5c106cde.pth',
+    'resnet34': 'https://download.pytorch.org/models/resnet34-333f7ec4.pth',
+    'resnet50': 'https://download.pytorch.org/models/resnet50-19c8e357.pth',
+    'resnet101': 'https://download.pytorch.org/models/resnet101-5d3b4d8f.pth',
+    'resnet152': 'https://download.pytorch.org/models/resnet152-b121ed2d.pth',
+    'resnext50_32x4d': 'https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth',
+    'resnext101_32x8d': 'https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth',
+    'wide_resnet50_2': 'https://download.pytorch.org/models/wide_resnet50_2-95faca4d.pth',
+    'wide_resnet101_2': 'https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth',
+}
+
+
+def conv3x3(P_x, in_planes: int, out_planes: int, stride: int = 1, groups: int = 1, dilation: int = 1) -> nn.Conv2d:
+    """3x3 convolution with padding"""
+    # return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
+    #                  padding=dilation, groups=groups, bias=False, dilation=dilation)
+    return distdl.nn.DistributedFeatureConv2d(P_x, in_planes, out_planes, kernel_size=3, stride=stride,
+                                              padding=dilation, groups=groups, bias=False, dilation=dilation)
+
+
+def conv1x1(P_x, in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
+    """1x1 convolution"""
+    #return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+    return distdl.nn.DistributedFeatureConv2d(P_x, in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class BasicBlock(nn.Module):
+    expansion: int = 1
+
+    def __init__(
+        self,
+        P_x,
+        inplanes: int,
+        planes: int,
+        stride: int = 1,
+        downsample: Optional[nn.Module] = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Optional[Callable[..., nn.Module]] = None
+    ) -> None:
+        super(BasicBlock, self).__init__()
+        if norm_layer is None:
+            norm_layer = distdl.nn.DistributedBatchNorm
+        if groups != 1 or base_width != 64:
+            raise ValueError('BasicBlock only supports groups=1 and base_width=64')
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv3x3(P_x, inplanes, planes, stride)
+        self.bn1 = norm_layer(P_x, planes)
+        self.relu = nn.ReLU(inplace=False)
+        self.conv2 = conv3x3(P_x, planes, planes)
+        self.bn2 = norm_layer(P_x, planes)
+        self.downsample = downsample
+        self.stride = stride
+        self.P_x = P_x
+
+    def forward(self, x: Tensor) -> Tensor:
+        # Note: This layer expects balanced inputs.
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
+    # while original implementation places the stride at the first 1x1 convolution(self.conv1)
+    # according to "Deep residual learning for image recognition"https://arxiv.org/abs/1512.03385.
+    # This variant is also known as ResNet V1.5 and improves accuracy according to
+    # https://ngc.nvidia.com/catalog/model-scripts/nvidia:resnet_50_v1_5_for_pytorch.
+
+    expansion: int = 4
+
+    def __init__(
+        self,
+        P_x,
+        inplanes: int,
+        planes: int,
+        stride: int = 1,
+        downsample: Optional[nn.Module] = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Optional[Callable[..., nn.Module]] = None
+    ) -> None:
+        super(Bottleneck, self).__init__()
+        if norm_layer is None:
+            norm_layer = distdl.nn.DistributedBatchNorm
+        width = int(planes * (base_width / 64.)) * groups
+        # Both self.conv2 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv1x1(P_x, inplanes, width)
+        self.bn1 = norm_layer(P_x, width)
+        self.conv2 = conv3x3(P_x, width, width, stride, groups, dilation)
+        self.bn2 = norm_layer(P_x, width)
+        self.conv3 = conv1x1(P_x, width, planes * self.expansion)
+        self.bn3 = norm_layer(P_x, planes * self.expansion)
+        self.relu = nn.ReLU(inplace=False)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x: Tensor) -> Tensor:
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Module):
+
+    def __init__(
+        self,
+        P_world,
+        parts: List[int],
+        block: Type[Union[BasicBlock, Bottleneck]],
+        layers: List[int],
+        num_classes: int = 1000,
+        zero_init_residual: bool = False,
+        groups: int = 1,
+        width_per_group: int = 64,
+        replace_stride_with_dilation: Optional[List[bool]] = None,
+        norm_layer: Optional[Callable[..., nn.Module]] = None
+    ) -> None:
+        super(ResNet, self).__init__()
+
+        # Set up the partitions
+        height, width = parts[0], parts[1]
+        self.P_base = P_world.create_partition_inclusive(np.arange(height*width))
+        if not self.P_base.active:
+            return
+        P_0_base = self.P_base.create_partition_inclusive([0])
+        self.P_0 = P_0_base.create_cartesian_topology_partition([1, 1, 1, 1])
+        P_x_base = self.P_base.create_partition_inclusive(np.arange(height*width))
+        self.P_x = P_x_base.create_cartesian_topology_partition([1, 1, height, width])
+
+        if norm_layer is None:
+            norm_layer = distdl.nn.DistributedBatchNorm
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            # each element in the tuple indicates if we should replace
+            # the 2x2 stride with a dilated convolution instead
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = distdl.nn.DistributedFeatureConv2d(self.P_x, 3, self.inplanes, kernel_size=7, stride=2, padding=3,
+                                                        bias=False)
+        self.bn1 = norm_layer(self.P_x, self.inplanes)
+        self.relu = nn.ReLU(inplace=False)
+        self.maxpool = distdl.nn.DistributedMaxPool2d(self.P_x, kernel_size=3, stride=2, padding=1)
+        self.rebalance = distdl.nn.DistributedTranspose(self.P_x, self.P_x)
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2,
+                                       dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2,
+                                       dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
+                                       dilate=replace_stride_with_dilation[2])
+        self.sr = distdl.nn.SumReduce(self.P_x, self.P_0)
+        self.bc = distdl.nn.Broadcast(self.P_0, self.P_x)
+        self.input_map = distdl.nn.DistributedTranspose(self.P_0, self.P_x)
+        if self.P_0.active:
+            self.fc = nn.Linear(512 * block.expansion, num_classes)
+
+        # A trick so that distributed network can work with optimizer
+        self.output = DistributedNetworkOutput(self.P_x)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                pass
+                #nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, distdl.nn.conv_feature.DistributedFeatureConv2d):
+                if m.P_wb_cart.active:
+                    #print(self.P_x.rank, type(m), m.weight.shape)
+                    nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, distdl.nn.batchnorm.DistributedBatchNorm):
+                if self.P_0.active:
+                    # TODO: We should update BatchNorm to match the PyTorch 'weight' 'bias'
+                    #       class variable names for the parameters.
+                    nn.init.constant_(m.gamma, 1)
+                    nn.init.constant_(m.beta, 0)
+
+        # Zero-initialize the last BN in each residual branch,
+        # so that the residual branch starts with zeros, and each residual block behaves like an identity.
+        # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    nn.init.constant_(m.bn3.gamma, 0)  # type: ignore[arg-type]
+                elif isinstance(m, BasicBlock):
+                    nn.init.constant_(m.bn2.gamma, 0)  # type: ignore[arg-type]
+
+    def _make_layer(self, block: Type[Union[BasicBlock, Bottleneck]], planes: int, blocks: int,
+                    stride: int = 1, dilate: bool = False) -> nn.Sequential:
+        norm_layer = self._norm_layer
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.P_x, self.inplanes, planes * block.expansion, stride),
+                norm_layer(self.P_x, planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(block(self.P_x, self.inplanes, planes, stride, downsample, self.groups,
+                            self.base_width, previous_dilation, norm_layer))
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(block(self.P_x, self.inplanes, planes, groups=self.groups,
+                                base_width=self.base_width, dilation=self.dilation,
+                                norm_layer=norm_layer))
+
+        return nn.Sequential(*layers)
+
+    def _avg_pool(self, x: Tensor) -> Tensor:
+        # Takes the input tensor and averages all features to size 1x1 on the root partition.
+        # In theory we should be able to use a DistributedAveragePool2d layer with a kernel
+        # equal to the size of the input.  However, halos will not extend more than one
+        # neighbor over, so this wouldn't work.
+        # Instead, this just simulates an adaptive average pooling layer by taking
+        # the local means (to shape [B, C, 1, 1]), then mean-reducing the results.
+        x = torch.mean(x, 2, keepdim=True)
+        x = torch.mean(x, 3, keepdim=True)
+        x = self.sr(x)
+        x /= self.P_x.shape.prod()
+        return x
+
+    def _forward_impl(self, x: Tensor) -> Tensor:
+        # See note [TorchScript super()]
+        x = self.input_map(x)
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+        x = self.rebalance(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = x.clone()
+        x = self._avg_pool(x)
+        if self.P_0.active:
+            x = torch.flatten(x, 1)
+            x = self.fc(x)
+        else:
+            x = x.clone()
+
+        x = self.output(x)
+
+        return x
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self._forward_impl(x)
+
+
+def _resnet(
+    P_world,
+    parts: List[int],
+    arch: str,
+    block: Type[Union[BasicBlock, Bottleneck]],
+    layers: List[int],
+    pretrained: bool,
+    progress: bool,
+    **kwargs: Any
+) -> ResNet:
+    model = ResNet(P_world, parts, block, layers, **kwargs)
+    return model
+
+
+def resnet18_dist(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNet-18 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    return _resnet(P_world, parts, 'resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress,
+                   **kwargs)
+
+
+def resnet34(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNet-34 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    return _resnet(P_world, parts, 'resnet34', BasicBlock, [3, 4, 6, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet50(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNet-50 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    return _resnet(P_world, parts, 'resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet101(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNet-101 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    return _resnet(P_world, parts, 'resnet101', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet152(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNet-152 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    return _resnet(P_world, parts, 'resnet152', Bottleneck, [3, 8, 36, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnext50_32x4d(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNeXt-50 32x4d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 4
+    return _resnet(P_world, parts, 'resnext50_32x4d', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+
+def resnext101_32x8d(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""ResNeXt-101 32x8d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 8
+    return _resnet(P_world, parts, 'resnext101_32x8d', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)
+
+
+def wide_resnet50_2(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_.
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet(P_world, parts, 'wide_resnet50_2', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+
+def wide_resnet101_2(P_world, parts: List[int] = [1, 4], pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    r"""Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_.
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    if pretrained:
+        raise NotImplementedError('Loading from pretrained model is not supported yet.')
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet(P_world, parts, 'wide_resnet101_2', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)

--- a/resnet/sequential_experiment.py
+++ b/resnet/sequential_experiment.py
@@ -1,0 +1,77 @@
+import time
+
+import torch
+from data_loader import get_data_loaders
+from network import generate_sequential_network
+
+torch.manual_seed(0)
+torch.set_num_threads(32)
+
+# Intel challenge:
+num_classes = 6
+train_data_dir = 'intel_challenge/seg_train/'
+test_data_dir = 'intel_challenge/seg_test/'
+
+resnet_sequential = generate_sequential_network(num_classes)
+
+parameters = [p for p in resnet_sequential.parameters()]
+criterion = torch.nn.CrossEntropyLoss()
+optimizer = torch.optim.Adam(parameters, lr=1e-3)
+
+max_batch_size = 64
+
+n_epochs = 10
+
+loud = True
+
+training_loader, test_loader = get_data_loaders(max_batch_size,
+                                                train_data_dir,
+                                                test_data_dir,
+                                                download=True,
+                                                dummy=False)
+
+# Adapted from https://github.com/activatedgeek/LeNet-5/blob/master/run.py
+loss_list, batch_list = [], []
+
+tt = time.time()
+for epoch in range(n_epochs):
+    tte = time.time()
+
+    for i, (images, labels) in enumerate(training_loader):
+
+        ttp = time.time()
+
+        optimizer.zero_grad()
+
+        output = resnet_sequential(images)
+
+        loss = criterion(output, labels)
+
+        loss_list.append(loss.detach().cpu().item())
+        batch_list.append(i+1)
+
+        if loud and i % 1 == 0:
+            print(f'Epoch {epoch}, Batch {i}, Loss: {loss_list[-1]}, time: {time.time() - ttp}')
+
+        loss.backward()
+        optimizer.step()
+
+    print(f"Epoch {epoch} time: {time.time() - tte}")
+
+print(f"Total time: {time.time() - tt}")
+
+total = 0
+total_correct = 0
+avg_loss = 0.0
+
+for i, (images, labels) in enumerate(test_loader):
+
+    total += max_batch_size
+    output = resnet_sequential(images)
+    avg_loss += criterion(output, labels).sum()
+    pred = output.detach().max(1)[1]
+    total_correct += pred.eq(labels.view_as(pred)).sum()
+
+perc = float(total_correct) / float(total)
+
+print(f"Total Correct: {total_correct}, Total: {total}, %: {perc}")


### PR DESCRIPTION
This adds all the variants for ResNet written with DistDL layers, as well as an equivalent sequential PyTorch approach.

Note: This depends on a fix for the following issue: https://github.com/distdl/distdl/issues/191